### PR TITLE
Add openpxl and build tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ MsLow for a bunch of nutty stuff!
 ## How to use:
 
 ### REQUIREMENTS!
+Visual C++ Build Tools https://go.microsoft.com/fwlink/?LinkId=691126
 # pip install -r requirements.txt
 
 ## autoupdate

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ packaging
 ecdsa
 google-cloud-translate
 pandas
+openpxl


### PR DESCRIPTION
openpxl is required by script but not currently in requirements.txt

fastxor requires C++ build tools 14.0 to install so added a link to the readme before pip install.